### PR TITLE
Docs update RegExp and RegExpMatch

### DIFF
--- a/sdk/lib/core/regexp.dart
+++ b/sdk/lib/core/regexp.dart
@@ -19,14 +19,21 @@ part of dart.core;
 /// and returns the first [RegExpMatch].
 /// All other methods in [RegExp] can be build from that.
 ///
+/// /// The following example finds first match of a regular expression in
+/// a string.
+/// ```dart
+/// RegExp exp = RegExp(r'Parse');
+/// String str = 'Parse my string';
+/// RegExpMatch match = exp.firstMatch(str);
+/// ```
 /// Use [allMatches] to look for all matches of a regular expression in
 /// a string.
 ///
 /// The following example finds all matches of a regular expression in
 /// a string.
 /// ```dart
-/// RegExp exp = RegExp(r"(\w+)");
-/// String str = "Parse my string";
+/// RegExp exp = RegExp(r'(\w+)');
+/// String str = 'Parse my string';
 /// Iterable<RegExpMatch> matches = exp.allMatches(str);
 /// ```
 ///
@@ -54,8 +61,8 @@ abstract class RegExp implements Pattern {
   /// Example:
   ///
   /// ```dart
-  /// var wordPattern = RegExp(r"(\w+)");
-  /// var bracketedNumberValue = RegExp("$key: \\[\\d+\\]");
+  /// var wordPattern = RegExp(r'(\w+)');
+  /// var bracketedNumberValue = RegExp('$key: \\[\\d+\\]');
   /// ```
   ///
   /// Notice the use of a _raw string_ in the first example, and a regular
@@ -87,17 +94,41 @@ abstract class RegExp implements Pattern {
   /// Finds the first match of the regular expression in the string [input].
   ///
   /// Returns `null` if there is no match.
+  /// ```dart
+  /// final string = '[00:13.37] This is a chat message.';
+  /// final regExp = RegExp(r'chat');
+  /// final match = regExp.firstMatch(string)!;
+  /// print(match[0]); // chat
+  /// ```
   RegExpMatch? firstMatch(String input);
 
   Iterable<RegExpMatch> allMatches(String input, [int start = 0]);
 
   /// Whether the regular expression has a match in the string [input].
+  /// ```dart
+  /// final string = 'Dash is a bird';
+  /// final regExp = RegExp(r'bird');
+  /// final match = regExp.hasMatch(string); // true
+  ///
+  /// final string = 'Dash is a bird';
+  /// final regExp = RegExp(r'dog');
+  /// final match = regExp.hasMatch(string); // false
+  /// ```
   bool hasMatch(String input);
 
   /// The substring of the first match of this regular expression in [input].
+  /// final string = 'Dash is a bird';
+  /// final regExp = RegExp(r'bird');
+  /// final match = regExp.stringMatch(string); // Match
+  ///
+  /// final string = 'Dash is a bird';
+  /// final regExp = RegExp(r'dog');
+  /// final match = regExp.stringMatch(string); // No match
   String? stringMatch(String input);
 
   /// The source regular expression string used to create this `RegExp`.
+  /// RegExp exp = RegExp(r'\p{L}');
+  /// print(exp.pattern); // \p{L}
   String get pattern;
 
   /// Whether this regular expression matches multiple lines.
@@ -112,6 +143,17 @@ abstract class RegExp implements Pattern {
   /// If the regular expression is not case sensitive, it will match an input
   /// letter with a pattern letter even if the two letters are different case
   /// versions of the same letter.
+  /// ```dart
+  /// RegExp exp = RegExp(r'STRING', caseSensitive: false);
+  /// String str = 'Parse my string';
+  /// Iterable<RegExpMatch> matches = exp.allMatches(str); // Has matches.
+  /// print(exp.isCaseSensitive); // false
+  ///
+  /// RegExp exp = RegExp(r'STRING', caseSensitive: true);
+  /// String str = 'Parse my string';
+  /// Iterable<RegExpMatch> matches = exp.allMatches(str); // No matches.
+  /// print(exp.isCaseSensitive); // true
+  /// ```
   bool get isCaseSensitive;
 
   /// Whether this regular expression is in Unicode mode.
@@ -124,6 +166,17 @@ abstract class RegExp implements Pattern {
   /// In Unicode mode, the syntax of the RegExp pattern is more restricted, but
   /// some pattern features, like Unicode property escapes, are only available in
   /// this mode.
+  /// ```dart
+  /// RegExp exp = RegExp(r'\p{L}', unicode: true);
+  /// print(exp.hasMatch('a')); // true
+  /// print(exp.hasMatch('b')); // true
+  /// print(exp.hasMatch('?')); // false
+  ///
+  /// RegExp exp = RegExp(r'\p{L}', unicode: false);
+  /// print(exp.hasMatch('a')); // false
+  /// print(exp.hasMatch('b')); // false
+  /// print(exp.hasMatch('?')); // false
+  /// ```
   @Since("2.4")
   bool get isUnicode;
 

--- a/sdk/lib/core/regexp.dart
+++ b/sdk/lib/core/regexp.dart
@@ -124,6 +124,7 @@ abstract class RegExp implements Pattern {
   bool hasMatch(String input);
 
   /// The substring of the first match of this regular expression in [input].
+  /// ```dart
   /// final string = 'Dash is a bird';
   /// final regExp = RegExp(r'bird');
   /// final match = regExp.stringMatch(string); // Match
@@ -131,11 +132,14 @@ abstract class RegExp implements Pattern {
   /// final string = 'Dash is a bird';
   /// final regExp = RegExp(r'dog');
   /// final match = regExp.stringMatch(string); // No match
+  /// ```
   String? stringMatch(String input);
 
   /// The source regular expression string used to create this `RegExp`.
+  /// ```dart
   /// RegExp exp = RegExp(r'\p{L}');
   /// print(exp.pattern); // \p{L}
+  /// ```
   String get pattern;
 
   /// Whether this regular expression matches multiple lines.

--- a/sdk/lib/core/regexp.dart
+++ b/sdk/lib/core/regexp.dart
@@ -19,12 +19,13 @@ part of dart.core;
 /// and returns the first [RegExpMatch].
 /// All other methods in [RegExp] can be build from that.
 ///
-/// /// The following example finds first match of a regular expression in
+/// The following example finds first match of a regular expression in
 /// a string.
 /// ```dart
-/// RegExp exp = RegExp(r'Parse');
+/// RegExp exp = RegExp(r'(\w+)');
 /// String str = 'Parse my string';
 /// RegExpMatch? match = exp.firstMatch(str);
+/// print(match![0]); // "Parse"
 /// ```
 /// Use [allMatches] to look for all matches of a regular expression in
 /// a string.
@@ -35,6 +36,15 @@ part of dart.core;
 /// RegExp exp = RegExp(r'(\w+)');
 /// String str = 'Parse my string';
 /// Iterable<RegExpMatch> matches = exp.allMatches(str);
+/// for (final m in matches) {
+///   print(m[0]);
+/// }
+/// ```
+/// The output of the example is:
+/// ```
+/// Parse
+/// my
+/// string
 /// ```
 ///
 /// Note the use of a _raw string_ (a string prefixed with `r`)
@@ -103,7 +113,7 @@ abstract class RegExp implements Pattern {
   /// Returns `null` if there is no match.
   /// ```dart
   /// final string = '[00:13.37] This is a chat message.';
-  /// final regExp = RegExp(r'chat');
+  /// final regExp = RegExp(r'c\w*');
   /// final match = regExp.firstMatch(string)!;
   /// print(match[0]); // chat
   /// ```
@@ -114,10 +124,9 @@ abstract class RegExp implements Pattern {
   /// Whether the regular expression has a match in the string [input].
   /// ```dart
   /// var string = 'Dash is a bird';
-  /// var regExp = RegExp(r'bird');
+  /// var regExp = RegExp(r'(humming)?bird');
   /// var match = regExp.hasMatch(string); // true
   ///
-  /// string = 'Dash is a bird';
   /// regExp = RegExp(r'dog');
   /// match = regExp.hasMatch(string); // false
   /// ```
@@ -126,10 +135,9 @@ abstract class RegExp implements Pattern {
   /// The substring of the first match of this regular expression in [input].
   /// ```dart
   /// var string = 'Dash is a bird';
-  /// var regExp = RegExp(r'bird');
+  /// var regExp = RegExp(r'(humming)?bird');
   /// var match = regExp.stringMatch(string); // Match
   ///
-  /// string = 'Dash is a bird';
   /// regExp = RegExp(r'dog');
   /// match = regExp.stringMatch(string); // No match
   /// ```
@@ -177,15 +185,17 @@ abstract class RegExp implements Pattern {
   /// some pattern features, like Unicode property escapes, are only available in
   /// this mode.
   /// ```dart
-  /// var regExp = RegExp(r'\p{L}', unicode: true);
+  /// var regExp = RegExp(r'^\p{L}$', unicode: true);
   /// print(regExp.hasMatch('a')); // true
   /// print(regExp.hasMatch('b')); // true
   /// print(regExp.hasMatch('?')); // false
+  /// print(regExp.hasMatch(r'p{L}')); // false
   ///
-  /// regExp = RegExp(r'\p{L}', unicode: false);
+  /// regExp = RegExp(r'^\p{L}$', unicode: false);
   /// print(regExp.hasMatch('a')); // false
   /// print(regExp.hasMatch('b')); // false
   /// print(regExp.hasMatch('?')); // false
+  /// print(regExp.hasMatch(r'p{L}')); // true
   /// ```
   @Since("2.4")
   bool get isUnicode;

--- a/sdk/lib/core/regexp.dart
+++ b/sdk/lib/core/regexp.dart
@@ -19,7 +19,7 @@ part of dart.core;
 /// and returns the first [RegExpMatch].
 /// All other methods in [RegExp] can be build from that.
 ///
-/// The following example finds first match of a regular expression in
+/// The following example finds the first match of a regular expression in
 /// a string.
 /// ```dart
 /// RegExp exp = RegExp(r'(\w+)');
@@ -165,11 +165,11 @@ abstract class RegExp implements Pattern {
   /// ```dart
   /// final str = 'Parse my string';
   /// var regExp = RegExp(r'STRING', caseSensitive: false);
-  /// Iterable<RegExpMatch> matches = regExp.allMatches(str); // Has matches.
+  /// final hasMatch = regExp.hasMatch(str); // Has matches.
   /// print(regExp.isCaseSensitive); // false
   ///
   /// regExp = RegExp(r'STRING', caseSensitive: true);
-  /// Iterable<RegExpMatch> caseSensitiveMatches = regExp.allMatches(str); // No matches.
+  /// final hasCaseSensitiveMatch = regExp.hasMatch(str); // No matches.
   /// print(regExp.isCaseSensitive); // true
   /// ```
   bool get isCaseSensitive;

--- a/sdk/lib/core/regexp.dart
+++ b/sdk/lib/core/regexp.dart
@@ -208,6 +208,41 @@ abstract class RegExp implements Pattern {
 /// Regular expression matches are [Match]es, but also include the ability
 /// to retrieve the names for any named capture groups and to retrieve
 /// matches for named capture groups by name instead of their index.
+///
+/// Example:
+/// ```dart
+/// const pattern =
+///     r'^\[(?<Time>\s*((?<hour>\d+)):((?<minute>\d+))\.((?<second>\d+)))\]'
+///     r'\s(?<Message>\s*(.*)$)';
+///
+/// final regExp = RegExp(
+///   pattern,
+///   multiLine: true,
+/// );
+///
+/// const multilineText = '[00:13.37] This is a first message.\n'
+///     '[01:15.57] This is a second message.\n';
+///
+/// RegExpMatch regExpMatch = regExp.firstMatch(multilineText)!;
+/// print(regExpMatch.groupNames.join('-')); // hour-minute-second-Time-Message.
+/// final time = regExpMatch.namedGroup('Time'); // 00:13.37
+/// final hour = regExpMatch.namedGroup('hour'); // 00
+/// final minute = regExpMatch.namedGroup('minute'); // 13
+/// final second = regExpMatch.namedGroup('second'); // 37
+/// final message =
+///     regExpMatch.namedGroup('Message'); // This is a first message.
+/// final date = regExpMatch.namedGroup('Date'); // Undefined `Date`, throws.
+///
+/// Iterable<RegExpMatch> matches = regExp.allMatches(multilineText);
+/// for (final m in matches) {
+///   print(m.namedGroup('Time'));
+///   print(m.namedGroup('Message'));
+///   // 00:13.37
+///   // This is a first message.
+///   // 01:15.57
+///   // This is a second message.
+/// }
+/// ```
 @Since("2.3")
 abstract class RegExpMatch implements Match {
   /// The string matched by the group named [name].

--- a/sdk/lib/core/regexp.dart
+++ b/sdk/lib/core/regexp.dart
@@ -89,6 +89,13 @@ abstract class RegExp implements Pattern {
   /// larger regular expression. Since a [String] is itself a [Pattern]
   /// which matches itself, converting the string to a regular expression
   /// isn't needed in order to search for just that string.
+  /// ```dart
+  /// print(RegExp.escape('dash@example.com')); // dash@example\.com
+  /// print(RegExp.escape('a+b')); // a\+b
+  /// print(RegExp.escape('a*b')); // a\*b
+  /// print(RegExp.escape('{a-b}')); // \{a-b\}
+  /// print(RegExp.escape('a?')); // a\?
+  /// ```
   external static String escape(String text);
 
   /// Finds the first match of the regular expression in the string [input].

--- a/sdk/lib/core/regexp.dart
+++ b/sdk/lib/core/regexp.dart
@@ -61,8 +61,8 @@ abstract class RegExp implements Pattern {
   /// Example:
   ///
   /// ```dart
-  /// var wordPattern = RegExp(r'(\w+)');
-  /// var digitPattern = RegExp(r'(\d+)');
+  /// final wordPattern = RegExp(r'(\w+)');
+  /// final digitPattern = RegExp(r'(\d+)');
   /// ```
   ///
   /// Notice the use of a _raw string_ in the first example, and a regular
@@ -137,8 +137,8 @@ abstract class RegExp implements Pattern {
 
   /// The source regular expression string used to create this `RegExp`.
   /// ```dart
-  /// RegExp exp = RegExp(r'\p{L}');
-  /// print(exp.pattern); // \p{L}
+  /// final regExp = RegExp(r'\p{L}');
+  /// print(regExp.pattern); // \p{L}
   /// ```
   String get pattern;
 
@@ -155,15 +155,14 @@ abstract class RegExp implements Pattern {
   /// letter with a pattern letter even if the two letters are different case
   /// versions of the same letter.
   /// ```dart
-  /// RegExp exp = RegExp(r'STRING', caseSensitive: false);
-  /// RegExp expWithCaseSensitive = RegExp(r'STRING', caseSensitive: true);
-  /// String str = 'Parse my string';
+  /// final str = 'Parse my string';
+  /// var regExp = RegExp(r'STRING', caseSensitive: false);
+  /// Iterable<RegExpMatch> matches = regExp.allMatches(str); // Has matches.
+  /// print(regExp.isCaseSensitive); // false
   ///
-  /// Iterable<RegExpMatch> matches = exp.allMatches(str); // Has matches.
-  /// print(exp.isCaseSensitive); // false
-  ///
-  /// Iterable<RegExpMatch> matches = expWithCaseSensitive.allMatches(str); // No matches.
-  /// print(exp.isCaseSensitive); // true
+  /// regExp = RegExp(r'STRING', caseSensitive: true);
+  /// Iterable<RegExpMatch> caseSensitiveMatches = regExp.allMatches(str); // No matches.
+  /// print(regExp.isCaseSensitive); // true
   /// ```
   bool get isCaseSensitive;
 
@@ -178,15 +177,15 @@ abstract class RegExp implements Pattern {
   /// some pattern features, like Unicode property escapes, are only available in
   /// this mode.
   /// ```dart
-  /// RegExp expWithUnicode = RegExp(r'\p{L}', unicode: true);
-  /// print(expWithUnicode.hasMatch('a')); // true
-  /// print(expWithUnicode.hasMatch('b')); // true
-  /// print(expWithUnicode.hasMatch('?')); // false
+  /// var regExp = RegExp(r'\p{L}', unicode: true);
+  /// print(regExp.hasMatch('a')); // true
+  /// print(regExp.hasMatch('b')); // true
+  /// print(regExp.hasMatch('?')); // false
   ///
-  /// RegExp expWithoutUnicode = RegExp(r'\p{L}', unicode: false);
-  /// print(expWithoutUnicode.hasMatch('a')); // false
-  /// print(expWithoutUnicode.hasMatch('b')); // false
-  /// print(expWithoutUnicode.hasMatch('?')); // false
+  /// regExp = RegExp(r'\p{L}', unicode: false);
+  /// print(regExp.hasMatch('a')); // false
+  /// print(regExp.hasMatch('b')); // false
+  /// print(regExp.hasMatch('?')); // false
   /// ```
   @Since("2.4")
   bool get isUnicode;

--- a/sdk/lib/core/regexp.dart
+++ b/sdk/lib/core/regexp.dart
@@ -24,7 +24,7 @@ part of dart.core;
 /// ```dart
 /// RegExp exp = RegExp(r'Parse');
 /// String str = 'Parse my string';
-/// RegExpMatch match = exp.firstMatch(str);
+/// RegExpMatch? match = exp.firstMatch(str);
 /// ```
 /// Use [allMatches] to look for all matches of a regular expression in
 /// a string.
@@ -62,7 +62,7 @@ abstract class RegExp implements Pattern {
   ///
   /// ```dart
   /// var wordPattern = RegExp(r'(\w+)');
-  /// var bracketedNumberValue = RegExp('$key: \\[\\d+\\]');
+  /// var digitPattern = RegExp(r'(\d+)');
   /// ```
   ///
   /// Notice the use of a _raw string_ in the first example, and a regular
@@ -113,25 +113,25 @@ abstract class RegExp implements Pattern {
 
   /// Whether the regular expression has a match in the string [input].
   /// ```dart
-  /// final string = 'Dash is a bird';
-  /// final regExp = RegExp(r'bird');
-  /// final match = regExp.hasMatch(string); // true
+  /// var string = 'Dash is a bird';
+  /// var regExp = RegExp(r'bird');
+  /// var match = regExp.hasMatch(string); // true
   ///
-  /// final string = 'Dash is a bird';
-  /// final regExp = RegExp(r'dog');
-  /// final match = regExp.hasMatch(string); // false
+  /// string = 'Dash is a bird';
+  /// regExp = RegExp(r'dog');
+  /// match = regExp.hasMatch(string); // false
   /// ```
   bool hasMatch(String input);
 
   /// The substring of the first match of this regular expression in [input].
   /// ```dart
-  /// final string = 'Dash is a bird';
-  /// final regExp = RegExp(r'bird');
-  /// final match = regExp.stringMatch(string); // Match
+  /// var string = 'Dash is a bird';
+  /// var regExp = RegExp(r'bird');
+  /// var match = regExp.stringMatch(string); // Match
   ///
-  /// final string = 'Dash is a bird';
-  /// final regExp = RegExp(r'dog');
-  /// final match = regExp.stringMatch(string); // No match
+  /// string = 'Dash is a bird';
+  /// regExp = RegExp(r'dog');
+  /// match = regExp.stringMatch(string); // No match
   /// ```
   String? stringMatch(String input);
 
@@ -156,13 +156,13 @@ abstract class RegExp implements Pattern {
   /// versions of the same letter.
   /// ```dart
   /// RegExp exp = RegExp(r'STRING', caseSensitive: false);
+  /// RegExp expWithCaseSensitive = RegExp(r'STRING', caseSensitive: true);
   /// String str = 'Parse my string';
+  ///
   /// Iterable<RegExpMatch> matches = exp.allMatches(str); // Has matches.
   /// print(exp.isCaseSensitive); // false
   ///
-  /// RegExp exp = RegExp(r'STRING', caseSensitive: true);
-  /// String str = 'Parse my string';
-  /// Iterable<RegExpMatch> matches = exp.allMatches(str); // No matches.
+  /// Iterable<RegExpMatch> matches = expWithCaseSensitive.allMatches(str); // No matches.
   /// print(exp.isCaseSensitive); // true
   /// ```
   bool get isCaseSensitive;
@@ -178,15 +178,15 @@ abstract class RegExp implements Pattern {
   /// some pattern features, like Unicode property escapes, are only available in
   /// this mode.
   /// ```dart
-  /// RegExp exp = RegExp(r'\p{L}', unicode: true);
-  /// print(exp.hasMatch('a')); // true
-  /// print(exp.hasMatch('b')); // true
-  /// print(exp.hasMatch('?')); // false
+  /// RegExp expWithUnicode = RegExp(r'\p{L}', unicode: true);
+  /// print(expWithUnicode.hasMatch('a')); // true
+  /// print(expWithUnicode.hasMatch('b')); // true
+  /// print(expWithUnicode.hasMatch('?')); // false
   ///
-  /// RegExp exp = RegExp(r'\p{L}', unicode: false);
-  /// print(exp.hasMatch('a')); // false
-  /// print(exp.hasMatch('b')); // false
-  /// print(exp.hasMatch('?')); // false
+  /// RegExp expWithoutUnicode = RegExp(r'\p{L}', unicode: false);
+  /// print(expWithoutUnicode.hasMatch('a')); // false
+  /// print(expWithoutUnicode.hasMatch('b')); // false
+  /// print(expWithoutUnicode.hasMatch('?')); // false
   /// ```
   @Since("2.4")
   bool get isUnicode;


### PR DESCRIPTION
Missing examples:

Parameters:

- isDotAll
- isMultiLine

Methods:

- allMatches (Why this is shown as it has no text, is this the right place?)